### PR TITLE
Fix bug with non-admin gaining access to tables after form submission

### DIFF
--- a/assets/scripts/database/events.js
+++ b/assets/scripts/database/events.js
@@ -46,7 +46,7 @@ const onSignOut = function (event) {
 const onCreateQuoteRequest = function (event) {
   event.preventDefault()
   const data = getFormFields(this)
-  if (app.user === undefined) {
+  if (app.user === undefined || app.user === null) {
     ui.onSignInPlease()
   } else {
     api.createQuoteRequest(data)
@@ -92,7 +92,7 @@ const onGetAllQuoteRequests = function (event) {
 const onCreateRegistration = function (event) {
   event.preventDefault()
   const data = getFormFields(this)
-  if (app.user !== undefined || app.user !== null) {
+  if (app.user === undefined || app.user === null) {
     ui.onSignInPlease()
   } else {
     api.createRegistration(data)

--- a/assets/scripts/ux.js
+++ b/assets/scripts/ux.js
@@ -3,8 +3,6 @@
 const homePage = function () {
   $('#account-signout').show()
   $('.text-content').show()
-  $('#get-all-requests').show()
-  $('#get-all-registrations').show()
   $('#reveal-change-password').show()
 
   $('#warning-messages').children().hide()


### PR DESCRIPTION
After submitting a quote request or registration, a non-admin user could access the admin table buttons. I removed the jQuery code revealing those buttons. 